### PR TITLE
[update] Bumped Facebook Graph API version 

### DIFF
--- a/wp-business-reviews-server.php
+++ b/wp-business-reviews-server.php
@@ -15,7 +15,7 @@
 // Include Trustpilot API proxy
 require_once __DIR__ . '/includes/trust-pilot-proxy.php';
 
-define( 'WPBRS_FACEBOOK_GRAPH_API_VERSION', 'v11.0' );
+define( 'WPBRS_FACEBOOK_GRAPH_API_VERSION', 'v14.0' );
 
 if (
 	isset( $_GET['wpbr_redirect'] )

--- a/wp-business-reviews-server.php
+++ b/wp-business-reviews-server.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Business Reviews Server
  * Plugin URI:  https://wpbusinessreviews.com
  * Description: The WP Business Reviews Server plugin provides authentication for platforms in the WP Business Reviews Client plugin.
- * Version:     0.1.2
+ * Version:     0.1.3
  * Author:      Team Impress
  * Author URI:  https://impress.org
  * License:     GPL-2.0+


### PR DESCRIPTION
This PR bumps the Graph API version from `11` to `14` to avoid issues stemming from the deprecation of the former.

![2024-05-21_18-23-15](https://github.com/iconicwp/wp-business-reviews-server/assets/3214928/6e974c25-c17c-403d-92ed-58d028468e96)